### PR TITLE
Fix schedule comparison to include period start

### DIFF
--- a/src/utils/scheduleUtils.js
+++ b/src/utils/scheduleUtils.js
@@ -52,7 +52,7 @@ export function getActivePeriods(now, schedule) {
     const [endH, endM] = p.end.split(":").map(Number);
     const start = dayjs(now).hour(startH).minute(startM).second(0);
     const end = dayjs(now).hour(endH).minute(endM).second(0);
-    return now.isAfter(start) && now.isBefore(end);
+    return now.isSameOrAfter(start) && now.isBefore(end);
   });
 
   if (current.length === 0) {


### PR DESCRIPTION
## Summary
- count a period as active the moment it begins by using `isSameOrAfter`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853051dee90832d973b57fce0dc0e75