### PR TITLE
Add fallback for no school days

### DIFF
--- a/src/components/SchoolDaysCounter.jsx
+++ b/src/components/SchoolDaysCounter.jsx
@@ -9,7 +9,19 @@ export default function SchoolDaysCounter() {
   const today = dayjs().startOf('day');
 
   const totalDays = instructionalDays.length;
-  const daysCompleted = instructionalDays.filter(dateStr =>
+
+  if (totalDays === 0) {
+    return (
+      <div className="w-72 bg-white dark:bg-gray-800 rounded-2xl shadow p-4 text-center">
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-white mb-3 flex items-center gap-2">
+          📅 <span>School Year Progress</span>
+        </h2>
+        <p className="text-gray-700 dark:text-gray-300">No school days defined</p>
+      </div>
+    );
+  }
+
+  const daysCompleted = instructionalDays.filter((dateStr) =>
     dayjs(dateStr).isSameOrBefore(today)
   ).length;
 


### PR DESCRIPTION
## Summary
- check totalDays before computing progress percentage
- show fallback message when no instructional days exist

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853085632b4832da85bfd62fc0586c2