### PR TITLE
Update school year checks

### DIFF
--- a/src/components/SchoolScheduleTimer.jsx
+++ b/src/components/SchoolScheduleTimer.jsx
@@ -13,7 +13,7 @@ function SchoolScheduleTimer() {
   const [summerBreak, setSummerBreak] = useState(false);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    const update = () => {
       const now = dayjs();
       setCurrentTime(now);
 
@@ -29,7 +29,10 @@ function SchoolScheduleTimer() {
       const periods = getActivePeriods(now, schedule);
 
       setActivePeriods(periods);
-    }, 5000);
+    };
+
+    update();
+    const interval = setInterval(update, 5000);
 
     return () => clearInterval(interval);
   }, []);

--- a/src/utils/scheduleUtils.js
+++ b/src/utils/scheduleUtils.js
@@ -86,8 +86,9 @@ export function getTimeLeft(endTime, now) {
 }
 
 export function isSchoolYearOver(date) {
+  const first = dayjs(scheduleData.instructionalYear.firstDay);
   const last = dayjs(scheduleData.instructionalYear.lastDay);
-  return date.isAfter(last, "day");
+  return date.isBefore(first, "day") || date.isAfter(last, "day");
 }
 
 

--- a/src/utils/scheduleUtils.test.js
+++ b/src/utils/scheduleUtils.test.js
@@ -36,11 +36,16 @@ describe('schedule utils', () => {
     expect(getTimeLeft('08:05', now)).toBe('5 min left');
   });
 
-  it('detects when the school year is over', () => {
+  it('detects when the school year is over or not yet started', () => {
     const { instructionalYear } = scheduleData;
+    const firstDay = dayjs(instructionalYear.firstDay);
     const lastDay = dayjs(instructionalYear.lastDay);
+    const beforeFirstDay = firstDay.subtract(1, 'day');
     const afterLastDay = lastDay.add(1, 'day');
+
+    expect(isSchoolYearOver(beforeFirstDay)).toBe(true);
     expect(isSchoolYearOver(afterLastDay)).toBe(true);
+    expect(isSchoolYearOver(firstDay)).toBe(false);
     expect(isSchoolYearOver(lastDay)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- end or start-of-year now counts as summer in school utils
- show "Happy Summer!" right away when not in session
- test early and late school year logic

## Testing
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6853303b6558832d9d461b149c532d6d